### PR TITLE
add ssh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bin/pi_ssh.sh

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,1 @@
+pi_ssh.sh

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,1 +1,0 @@
-pi_ssh.sh

--- a/bin/pi_ssh.sh
+++ b/bin/pi_ssh.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# requires sshpass
+# apt-get install sshpass
+
+# requires setting up ssh key authentication with the pi
+
+# assign variables
+declare -A pi_list
+
+# pi names can be according to location
+pi_list['<device_name>']='<device_ip>'
+
+while getopts h flag
+do
+	case "${flag}" in
+		h)
+			echo "./pi_ssh.sh <device_name>"
+			exit 1
+			;;
+	esac
+done
+
+if [[ $!pi_list[$1] ]]; then
+	ssh "pi@${pi_list[$1]}"
+fi


### PR DESCRIPTION
Add an ssh script that enables simple sshing into a specific pi.  Device names must be assigned in the script, and associated with an IP.  Personal device info left out with `git update-index --assume-unchanged`.